### PR TITLE
Move record_puzzle_access to be the last dependency

### DIFF
--- a/openday_scavenger/main.py
+++ b/openday_scavenger/main.py
@@ -127,9 +127,9 @@ app.include_router(
     puzzle_router,
     prefix="/puzzles",
     dependencies=[
-        Depends(record_puzzle_access),
         Depends(block_correctly_answered_puzzle),
         Depends(block_disabled_puzzles),
         Depends(auth_required),
+        Depends(record_puzzle_access),
     ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev-dependencies = [
     "coverage>=7.6.1",
     "mypy>=1.11.2",
     "pyright>=1.1.379",
+    "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.14.0",
     "pytest>=8.3.3",

--- a/tests/api/puzzles_tests/dependencies_test.py
+++ b/tests/api/puzzles_tests/dependencies_test.py
@@ -1,0 +1,178 @@
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy.orm import Session
+
+from openday_scavenger.api.puzzles.dependencies import (
+    block_correctly_answered_puzzle,
+    block_disabled_puzzles,
+    get_puzzle_name,
+    record_puzzle_access,
+)
+from openday_scavenger.api.puzzles.exceptions import (
+    DisabledPuzzleError,
+    PuzzleCompletedError,
+    PuzzleNotFoundError,
+    UnknownPuzzleError,
+)
+from openday_scavenger.api.puzzles.schemas import PuzzleCreate
+from openday_scavenger.api.puzzles.service import compare_answer
+from openday_scavenger.api.puzzles.service import create as create_puzzle
+from openday_scavenger.api.visitors.exceptions import VisitorUIDInvalidError
+from openday_scavenger.api.visitors.schemas import VisitorPoolCreate
+from openday_scavenger.api.visitors.service import create as create_visitor
+from openday_scavenger.api.visitors.service import create_visitor_pool, get_visitor_pool
+
+
+@pytest.mark.asyncio
+class TestPuzzlesDependencies:
+    """Explicitely test dependencies, since most of the times
+    they are overridden in normal endpoint tests
+    """
+
+    async def test_get_puzzle_name(self) -> None:
+        """Assert that the puzzle name is correctly extracted from the request path"""
+        request = Mock(url=Mock(path="/puzzles/demo"))
+        assert await get_puzzle_name(request) == "demo"
+
+    async def test_get_puzzle_name_invalid(self) -> None:
+        """Assert that an exception is raised when the puzzle name is not found in the request path"""
+        request = Mock(url=Mock(path="/foo/bar"))
+        with pytest.raises(UnknownPuzzleError):
+            await get_puzzle_name(request)
+
+    async def test_block_disabled_puzzles(self, empty_db: Session) -> None:
+        """Test that an existing, enabled puzzle is not blocked"""
+        create_puzzle(empty_db, puzzle_in=PuzzleCreate(name="foo", answer="", active=True))
+        await block_disabled_puzzles(empty_db, "foo")
+
+    async def test_block_disabled_puzzles_disabled(self, empty_db: Session) -> None:
+        """Test that an existing, disabled puzzle is blocked"""
+        create_puzzle(empty_db, puzzle_in=PuzzleCreate(name="foo", answer="", active=False))
+        with pytest.raises(DisabledPuzzleError):
+            await block_disabled_puzzles(empty_db, "foo")
+
+    async def test_block_disabled_puzzles_not_found(self, empty_db: Session) -> None:
+        """Test that a non-existing puzzle is blocked"""
+        with pytest.raises(UnknownPuzzleError):
+            await block_disabled_puzzles(empty_db, "foo")
+
+    async def test_block_correctly_answered_puzzle(self, empty_db: Session) -> None:
+        """Test that a correctly answered puzzle is blocked"""
+
+        _puzzle_name = "foo"
+        _answer = "baz"
+
+        # create a puzzle
+        create_puzzle(
+            empty_db,
+            puzzle_in=PuzzleCreate(
+                name=_puzzle_name,
+                answer=_answer,
+                active=True,
+            ),
+        )
+
+        # create a visitor pool
+        create_visitor_pool(
+            empty_db,
+            pool_in=VisitorPoolCreate(number_of_entries=1),
+        )
+        # and get it back
+        visitor_pool = get_visitor_pool(empty_db)
+        _visitor_uid = visitor_pool[0].uid
+
+        # register the visitor
+        create_visitor(empty_db, visitor_uid=_visitor_uid)
+
+        # create a mock visitor auth
+        visitor = Mock(uid=_visitor_uid, is_active=True)
+
+        # record that user has answered the puzzle.
+        # use the "compare answer" function to register the correct answer
+        compare_answer(
+            empty_db,
+            puzzle_name=_puzzle_name,
+            visitor_auth=visitor,
+            answer=_answer,
+        )
+
+        # call dependency
+        with pytest.raises(PuzzleCompletedError):
+            await block_correctly_answered_puzzle(
+                db=empty_db,
+                visitor=visitor,
+                puzzle_name=_puzzle_name,
+            )
+
+    async def test_record_puzzle_access(
+        self,
+        empty_db: Session,
+        mocker: MockerFixture,
+    ) -> None:
+        """Test recording access to an existing, active puzzle"""
+        from openday_scavenger.api.puzzles import dependencies as puzzle_deps
+
+        _puzzle_name = "foo"
+        _answer = "baz"
+
+        # create a puzzle
+        create_puzzle(
+            empty_db,
+            puzzle_in=PuzzleCreate(
+                name=_puzzle_name,
+                answer=_answer,
+                active=True,
+            ),
+        )
+
+        # create a visitor pool
+        create_visitor_pool(
+            empty_db,
+            pool_in=VisitorPoolCreate(number_of_entries=1),
+        )
+        # and get it back
+        visitor_pool = get_visitor_pool(empty_db)
+        _visitor_uid = visitor_pool[0].uid
+
+        # register the visitor
+        create_visitor(empty_db, visitor_uid=_visitor_uid)
+
+        # create a mock visitor auth
+        visitor = Mock(uid=_visitor_uid, is_active=True)
+
+        # call dependency
+        spy = mocker.spy(puzzle_deps, "record_access")
+        await record_puzzle_access(
+            db=empty_db,
+            visitor=visitor,
+            puzzle_name=_puzzle_name,
+        )
+        spy.assert_called()
+
+    @pytest.mark.parametrize(
+        ["func_raises", "dependency_raises"],
+        [
+            (VisitorUIDInvalidError, VisitorUIDInvalidError),
+            (PuzzleNotFoundError, UnknownPuzzleError),
+        ],
+    )
+    async def test_record_puzzle_access_unknown(
+        self,
+        empty_db: Session,
+        mocker: MockerFixture,
+        func_raises: Exception,
+        dependency_raises: Exception,
+    ) -> None:
+        """Test that failing recording access raises correct exception"""
+        mocker.patch(
+            "openday_scavenger.api.puzzles.dependencies.record_access",
+            side_effect=func_raises,
+        )
+        with pytest.raises(dependency_raises):  # type: ignore  # possibly https://github.com/microsoft/pyright/discussions/3988
+            await record_puzzle_access(
+                db=empty_db,
+                visitor=Mock(uid="foo", is_active=True),
+                puzzle_name="bar",
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -377,6 +377,7 @@ dev = [
     { name = "mypy" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
@@ -400,6 +401,7 @@ dev = [
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "pyright", specifier = ">=1.1.379" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "ruff", specifier = ">=0.6.4" },
@@ -559,6 +561,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/c6cf50ce320cf8611df7a1254d86233b3df7cc07f9b5f5cbcb82e08aa534/pytest_asyncio-0.24.0.tar.gz", hash = "sha256:d081d828e576d85f875399194281e92bf8a68d60d72d1a2faf2feddb6c46b276", size = 49855 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/31/6607dab48616902f76885dfcf62c08d929796fc3b2d2318faf9fd54dbed9/pytest_asyncio-0.24.0-py3-none-any.whl", hash = "sha256:a811296ed596b69bf0b6f3dc40f83bcaf341b155a269052d82efa2b25ac7037b", size = 18024 },
 ]
 
 [[package]]


### PR DESCRIPTION
Trying to record access to a puzzle before checking that the puzzle exists and is allowed was breaking the mechanism that should return a 404 when trying to access an unknown puzzle.

This is because `record_puzzle_access` uses the service call to `get` a puzzle, which returns a `PuzzleNotFoundError` which inherits from `RuntimeError`, not `HTTPException`, so it's not handled correctly.

Moving the dependency to the end of the list fixes the issue, since now getting to `record_puzzle_access` requires the other checks to have passed.

An alternative would be to change `record_puzzle_access` (which is a dependency) so that it wraps the call to `record_access` (a service function) in a try-except block like so
``` python

async def record_puzzle_access(
    db: Annotated["Session", Depends(get_db)],
    visitor: Annotated[VisitorAuth, Depends(get_auth_visitor)],
    puzzle_name: Annotated[str, Depends(get_puzzle_name)],
):
    """
    ...
    """
    try:
        record_access(db_session=db, puzzle_name=puzzle_name, visitor_auth=visitor)
    except PuzzleNotFoundError as e:
        raise UnknownPuzzleError(
            status_code=status.HTTP_404_NOT_FOUND,
            detail=f"No puzzle with the name {puzzle_name} is registered in the database",
        ) from e
    except ...

```
