### PR TITLE
Itty-bitty fix: force jsonable encoder on first storing of state as well

### DIFF
--- a/openday_scavenger/api/puzzles/service.py
+++ b/openday_scavenger/api/puzzles/service.py
@@ -419,7 +419,10 @@ def set_puzzle_state(
     # If the state doesn't exist yet, create it, otherwise overwrite the state information
     if state_model is None:
         state_model = State(
-            puzzle=puzzle, visitor=visitor, updated_at=datetime.now(), state=json.dumps(state)
+            puzzle=puzzle,
+            visitor=visitor,
+            updated_at=datetime.now(),
+            state=jsonable_encoder(json.dumps(state)),
         )
         try:
             db_session.add(state_model)


### PR DESCRIPTION
`jsonable_encoder` was used when updating a state, but not when storing it in the first place