### PR TITLE
Add puzzle bulk download/upload

### DIFF
--- a/openday_scavenger/api/custom_responses.py
+++ b/openday_scavenger/api/custom_responses.py
@@ -1,0 +1,22 @@
+import json
+import typing
+
+from fastapi import Response
+
+
+class PrettyJSONResponse(Response):
+    """Equivilant to the FastAPI JSONResponse class but 'pretty prints' the JSON"""
+
+    media_type = "application/json"
+
+    def render(self, content: typing.Any) -> bytes:
+        # Avoid using this for endpoints that are used often as it is a blocking operation
+        # There are ways of making this non blocking but it is only used for a utility endpoint
+        # so not a big issue for now
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=2,
+            separators=(", ", ": "),
+        ).encode("utf-8")

--- a/openday_scavenger/api/puzzles/schemas.py
+++ b/openday_scavenger/api/puzzles/schemas.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic import BaseModel
 
 from openday_scavenger.api.visitors.schemas import VisitorAuth
@@ -32,3 +34,7 @@ class PuzzleAccess(BaseModel):
 class ResponseTestCreate(BaseModel):
     number_visitors: int = 3000
     number_wrong_answers: int = 3
+
+
+class PuzzleJson(BaseModel):
+    puzzles: List[dict]

--- a/openday_scavenger/api/puzzles/service.py
+++ b/openday_scavenger/api/puzzles/service.py
@@ -525,10 +525,10 @@ def generate_test_data(
         raise
 
 
-def upsert_puzzle_json(db_session: Session, puzzle_data: PuzzleJson):
+def upsert_puzzle_json(db_session: Session, puzzle_json: PuzzleJson):
     existing_puzzles_by_id = {item.id: item for item in get_all(db_session)}
 
-    for puzzle in puzzle_data.puzzles:
+    for puzzle in puzzle_json.puzzles:
         existing_puzzle = "id" in puzzle and existing_puzzles_by_id[puzzle["id"]]
         if existing_puzzle:
             _ = update(db_session, existing_puzzle.name, PuzzleUpdate(**puzzle))

--- a/openday_scavenger/api/puzzles/service.py
+++ b/openday_scavenger/api/puzzles/service.py
@@ -26,7 +26,7 @@ from .exceptions import (
     PuzzleNotFoundError,
     PuzzleUpdatedError,
 )
-from .schemas import PuzzleCreate, PuzzleUpdate
+from .schemas import PuzzleCreate, PuzzleJson, PuzzleUpdate
 
 __all__ = (
     "get_all",
@@ -523,3 +523,14 @@ def generate_test_data(
     except:
         db_session.rollback()
         raise
+
+
+def upsert_puzzle_json(db_session: Session, puzzle_data: PuzzleJson):
+    existing_puzzles_by_id = {item.id: item for item in get_all(db_session)}
+
+    for puzzle in puzzle_data.puzzles:
+        existing_puzzle = "id" in puzzle and existing_puzzles_by_id[puzzle["id"]]
+        if existing_puzzle:
+            _ = update(db_session, existing_puzzle.name, PuzzleUpdate(**puzzle))
+        else:
+            _ = create(db_session, PuzzleCreate(**puzzle))

--- a/openday_scavenger/views/admin/puzzles.py
+++ b/openday_scavenger/views/admin/puzzles.py
@@ -18,6 +18,7 @@ from openday_scavenger.api.puzzles.service import (
     get,
     get_all,
     update,
+    upsert_puzzle_json,
 )
 from openday_scavenger.config import get_settings
 
@@ -143,13 +144,6 @@ async def upload_json(
     parsed_file = json.loads(file_contents)
     puzzle_data = PuzzleJson(**parsed_file)
 
-    existing_puzzles_by_id = {item.id: item for item in get_all(db)}
-
-    for puzzle in puzzle_data.puzzles:
-        existing_puzzle = "id" in puzzle and existing_puzzles_by_id[puzzle["id"]]
-        if existing_puzzle:
-            _ = update(db, existing_puzzle.name, PuzzleUpdate(**puzzle))
-        else:
-            _ = create(db, PuzzleCreate(**puzzle))
+    upsert_puzzle_json(db, puzzle_data)
 
     return await _render_puzzles_table(request, db)

--- a/openday_scavenger/views/admin/puzzles.py
+++ b/openday_scavenger/views/admin/puzzles.py
@@ -126,10 +126,11 @@ async def _render_puzzles_table(request: Request, db: Annotated["Session", Depen
 
 @router.get("/download-json")
 async def download_json(db: Annotated["Session", Depends(get_db)]):
+    """Downloads a JSON dump of all puzzle data"""
     puzzles = get_all(db)
 
     # The puzzle JSON downloads might need to be editable by humans
-    # and its easier to have it formatted by default
+    # and its easier to have it pretty formatted by default
     return PrettyJSONResponse(
         {"puzzles": jsonable_encoder(puzzles)},
         headers={"Content-Disposition": "attachment; filename=puzzle_data.json"},
@@ -140,10 +141,11 @@ async def download_json(db: Annotated["Session", Depends(get_db)]):
 async def upload_json(
     request: Request, file: UploadFile, db: Annotated["Session", Depends(get_db)]
 ):
+    """Bulk upserts multiple puzzles and updates the table"""
     file_contents = await file.read()
-    parsed_file = json.loads(file_contents)
-    puzzle_data = PuzzleJson(**parsed_file)
+    raw_json = json.loads(file_contents)
+    puzzle_json = PuzzleJson(**raw_json)
 
-    upsert_puzzle_json(db, puzzle_data)
+    upsert_puzzle_json(db, puzzle_json)
 
     return await _render_puzzles_table(request, db)

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -11,16 +11,20 @@
     <div class="d-flex mb-3">
         <div class="me-auto p-2"></div>
         <div class="p-2">
-            <a class="btn btn-secondary" href="/admin/puzzles/download-json"><i class="fa-regular fa-download"></i> Download JSON</a>
+            <a class="btn btn-secondary" href="/admin/puzzles/download-json"><i class="fa-regular fa-download"></i>
+                Download JSON</a>
         </div>
         <div class="p-2">
-            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#uploadJsonModal"><i class="fa-regular fa-upload"></i> Upload JSON</button>
+            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#uploadJsonModal"><i
+                    class="fa-regular fa-upload"></i> Upload JSON</button>
         </div>
         <div class="p-2">
-            <a class="btn btn-secondary" href="/admin/puzzles/download-pdf"><i class="fa-regular fa-qrcode"></i> Download All QR Codes</a>
+            <a class="btn btn-secondary" href="/admin/puzzles/download-pdf"><i class="fa-regular fa-qrcode"></i>
+                Download All QR Codes</a>
         </div>
         <div class="p-2">
-            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#addPuzzleModal"><i class="fa-regular fa-circle-plus"></i> Add new Puzzle</button>
+            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#addPuzzleModal"><i
+                    class="fa-regular fa-circle-plus"></i> Add new Puzzle</button>
         </div>
     </div>
     <div id="puzzle-table" hx-get="/admin/puzzles/table" hx-trigger="load" hx-swap="innerHTML"></div>
@@ -30,90 +34,93 @@
 <!-- Modal -->
 <div class="modal fade modal-lg" id="addPuzzleModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h1 class="modal-title fs-5">Add a new Puzzle to the Scavenger Hunt</h1>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-        </div>
-        <form id='puzzle-add-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/puzzles' hx-ext='json-enc' hx-swap="innerHTML" hx-target="#puzzle-table">
-            <div class="modal-body">
-                <div class="container">
-                    <div class="row">
-                        <div class="col">
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Name:</label>
-                                <input type="text" id="name" name="name" class="form-control">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5">Add a new Puzzle to the Scavenger Hunt</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id='puzzle-add-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/puzzles'
+                hx-ext='json-enc' hx-swap="innerHTML" hx-target="#puzzle-table">
+                <div class="modal-body">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col">
+                                <div class="mb-3">
+                                    <label for="name" class="form-label">Name:</label>
+                                    <input type="text" id="name" name="name" class="form-control">
+                                </div>
+
+                                <div class="mb-3">
+                                    <label for="name" class="form-label">Location:</label>
+                                    <input type="text" id="location" name="location" class="form-control">
+                                </div>
                             </div>
-                            
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Location:</label>
-                                <input type="text" id="location" name="location" class="form-control">
-                            </div>
-                        </div>
-                        
-                        <div class="col">
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Answer:</label>
-                                <input type="text" id="answer" name="answer" class="form-control">
-                            </div>
-    
-                            <div class="mb-3">
-                                <label for="name" class="form-label">Notes:</label>
-                                <input type="text" id="notes" name="notes" class="form-control">
+
+                            <div class="col">
+                                <div class="mb-3">
+                                    <label for="name" class="form-label">Answer:</label>
+                                    <input type="text" id="answer" name="answer" class="form-control">
+                                </div>
+
+                                <div class="mb-3">
+                                    <label for="name" class="form-label">Notes:</label>
+                                    <input type="text" id="notes" name="notes" class="form-control">
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="modal-footer">
-                <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Add Puzzle</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-            </div>
-        </form>
-      </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Add Puzzle</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
     </div>
-  </div>
+</div>
 
 
-  <div class="modal fade modal-lg" id="uploadJsonModal" tabindex="-1">
+<div class="modal fade modal-lg" id="uploadJsonModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h1 class="modal-title fs-5">Upload a JSON file with puzzle data</h1>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-        </div>
-        <form id='upload-json-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/puzzles/upload-json' hx-swap="innerHTML" hx-target="#puzzle-table">
-            <div class="modal-body">
-                <div class="container">
-                    <div class="row">
-                        <div class="col">
-                            <div class="mb-6 mb-3">
-                                Tip: To make sure you got the format right, use the 'Download JSON' button first and edit the existing data
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5">Upload a JSON file with puzzle data</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id='upload-json-form' class="mt-3" hx-encoding='multipart/form-data'
+                hx-post='/admin/puzzles/upload-json' hx-swap="innerHTML" hx-target="#puzzle-table">
+                <div class="modal-body">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col">
+                                <div class="mb-6 mb-3">
+                                    Tip: To make sure you got the format right, use the 'Download JSON' button first and
+                                    edit the existing data
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row">
-                        <div class="col">
-                            <div class="mb-6">
-                                <label for="json-file" class="form-label">File:</label>
-                                <input type="file" id="json-file" name="file" class="form-control">
+                        <div class="row">
+                            <div class="col">
+                                <div class="mb-6">
+                                    <label for="json-file" class="form-label">File:</label>
+                                    <input type="file" id="json-file" name="file" class="form-control">
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="modal-footer">
-                <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Upload</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-            </div>
-        </form>
-      </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Upload</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
     </div>
-  </div>
+</div>
 
-  <div class="modal fade modal-lg" id="editPuzzleModal" tabindex="-1">
+<div class="modal fade modal-lg" id="editPuzzleModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content"></div>
     </div>
-  </div>
+</div>
 {% endblock %}

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -107,8 +107,8 @@
                         <div class="row">
                             <div class="col">
                                 <div class="mb-6">
-                                    <label for="json-file" class="form-label">File:</label>
-                                    <input type="file" id="json-file" name="file" class="form-control">
+                                    <label for="json-file" class="form-label">File to upload:</label>
+                                    <input type="file" id="json-file" name="file" class="form-control" accept="application/json">
                                 </div>
                             </div>
                         </div>

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -94,8 +94,13 @@
                         <div class="row">
                             <div class="col">
                                 <div class="mb-6 mb-3">
+                                    Note: The uploaded data will either:
+                                    <ul>
+                                        <li>insert a new puzzle if the 'id' attribute is missing or doesn't match an existing puzzle</li>
+                                        <li>update existing data if the ID matches an existing puzzle</li>
+                                    </ul>
                                     Tip: To make sure you got the format right, use the 'Download JSON' button first and
-                                    edit the existing data
+                                    edit the existing data.
                                 </div>
                             </div>
                         </div>

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -11,6 +11,12 @@
     <div class="d-flex mb-3">
         <div class="me-auto p-2"></div>
         <div class="p-2">
+            <a class="btn btn-secondary" href="/admin/puzzles/download-json"><i class="fa-regular fa-download"></i> Download JSON</a>
+        </div>
+        <div class="p-2">
+            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#uploadJsonModal"><i class="fa-regular fa-upload"></i> Upload JSON</button>
+        </div>
+        <div class="p-2">
             <a class="btn btn-secondary" href="/admin/puzzles/download-pdf"><i class="fa-regular fa-qrcode"></i> Download All QR Codes</a>
         </div>
         <div class="p-2">
@@ -61,6 +67,43 @@
             </div>
             <div class="modal-footer">
                 <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Add Puzzle</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+
+  <div class="modal fade modal-lg" id="uploadJsonModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h1 class="modal-title fs-5">Upload a JSON file with puzzle data</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <form id='upload-json-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/puzzles/upload-json' hx-swap="innerHTML" hx-target="#puzzle-table">
+            <div class="modal-body">
+                <div class="container">
+                    <div class="row">
+                        <div class="col">
+                            <div class="mb-6 mb-3">
+                                Tip: To make sure you got the format right, use the 'Download JSON' button first and edit the existing data
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                            <div class="mb-6">
+                                <label for="json-file" class="form-label">File:</label>
+                                <input type="file" id="json-file" name="file" class="form-control">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="submit" class="btn btn-primary" data-bs-dismiss="modal">Upload</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
             </div>
         </form>


### PR DESCRIPTION
Fixes #59

The puzzle admin page now has two extra buttons:
- A "Download JSON" button which will export all the puzzles in JSON format
- An "Upload JSON" button which will import puzzles, updating existing puzzles if the ID attribute matches and existing one, and creating new puzzles where the ID is missing or doesn't match an existing puzzle

![image](https://github.com/user-attachments/assets/3d7a6851-43a7-4bad-9929-fdee3aaf7eb3)
