### PR TITLE
Allow mixed case for anagram puzzles

### DIFF
--- a/openday_scavenger/puzzles/shuffleanagram/static/styles.css
+++ b/openday_scavenger/puzzles/shuffleanagram/static/styles.css
@@ -26,8 +26,8 @@ h1 {
 /* Style for the form */
 form {
     max-width: 600px;
-    margin: 50px auto;
-    padding: 20px;
+    margin: 30px auto;
+    padding: 10px;
     background-color: #ffffff;
     border: 1px solid #dee2e6;
     border-radius: 5px;

--- a/openday_scavenger/puzzles/shuffleanagram/templates/index.html
+++ b/openday_scavenger/puzzles/shuffleanagram/templates/index.html
@@ -27,7 +27,7 @@
         </button>
     </div>
 
-    <form id='form' method='POST' action='/submission' class="text-center" onsubmit="prepareSubmission">
+    <form id='form' method='POST' action='/submission' class="text-center">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <div class="form-group mb-1">
             <label for="raw-answer">Your answer:</label><br>

--- a/openday_scavenger/puzzles/shuffleanagram/templates/index.html
+++ b/openday_scavenger/puzzles/shuffleanagram/templates/index.html
@@ -26,16 +26,27 @@
         </button>
     </div>
 
-    <form id='form' method='POST' action='/submission' class="text-center">
+    <form id='form' method='POST' action='/submission' class="text-center" onsubmit="prepareSubmission">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <div class="form-group">
-            <label for="answer">Your answer:</label><br>
-            <input type="text" id="answer" name="answer" pattern="[a-z]+" placeholder="(lowercase letters only)" class="form-control d-inline-block w-50">
+            <label for="raw-answer">Your answer:</label><br>
+            <input type="text" id="raw-answer" name="raw-answer" class="form-control d-inline-block w-50" onchange="updateAnswer();">
+            <input type="hidden" id="answer" name="answer">
         </div>
         <button class="btn btn-custom">
             Submit your answer
         </button>
     </form>
 </body>
+
+<script>
+    // Until we get https://github.com/AustralianSynchrotron/openday-scavenger/issues/118 done this workaround
+    // makes sure that the answer is always in lower case so it matches the answer in the database
+    function updateAnswer() {
+        const rawAnswerElement = document.getElementById('raw-answer');
+        const answerElement = document.getElementById('answer');
+        answerElement.value = rawAnswerElement.value.toLowerCase();
+    }
+</script>
 
 </html>

--- a/openday_scavenger/puzzles/shuffleanagram/templates/index.html
+++ b/openday_scavenger/puzzles/shuffleanagram/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <!-- Bootstrap CSS -->
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
@@ -28,9 +29,9 @@
 
     <form id='form' method='POST' action='/submission' class="text-center" onsubmit="prepareSubmission">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
-        <div class="form-group">
+        <div class="form-group mb-1">
             <label for="raw-answer">Your answer:</label><br>
-            <input type="text" id="raw-answer" name="raw-answer" class="form-control d-inline-block w-50" onchange="updateAnswer();">
+            <input type="text" id="raw-answer" name="raw-answer" class="form-control d-inline-block w-60" onchange="updateAnswer();">
             <input type="hidden" id="answer" name="answer">
         </div>
         <button class="btn btn-custom">


### PR DESCRIPTION
It might not be the cleanest solution but is probably the best workaround we have until https://github.com/AustralianSynchrotron/openday-scavenger/issues/118 is done

It words because the server expects the correct answer to be in the form element "answer" but it doesn't care what type of input the "answer" form element is, so we can make the "answer" form element hidden and put whatever we want in there programmatically.

I think we do this elsewhere for more complex puzzles anyway.