### PR TITLE
Make HTML templates more consistent

### DIFF
--- a/.djlint_rules.yaml
+++ b/.djlint_rules.yaml
@@ -1,0 +1,7 @@
+- rule:
+    name: A001
+    message: Consider adding a viewport meta tag.
+    flags: re.DOTALL|re.I
+    # <meta name="viewport" content="width=device-width, initial-scale=1"> is a good starting point
+    patterns:
+      - <html[^>]*?>(?:(?!<meta[^>]*?name=([\"|'])viewport\b).)*</html>

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Ruff Format
         run: uvx ruff format
 
+      - name: HTML Template Lint (djlint)
+        run:  uv run djlint openday_scavenger/
+
       - name: Run tests
         run: uv run pytest tests
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,9 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+- repo: https://github.com/djlint/djLint
+  rev: v1.35.2
+  hooks:
+    - id: djlint-jinja
+      files: "\\.html"
+      types_or: ["html"]

--- a/openday_scavenger/puzzles/ads_question_answer_matchup/static/index.html
+++ b/openday_scavenger/puzzles/ads_question_answer_matchup/static/index.html
@@ -1,6 +1,8 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
+    <title>ADS Question Answer Matchup Puzzle</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
@@ -50,7 +52,7 @@
                     <div class="list-group-item tinted list-row" id="data4">150</div>
                     <div class="list-group-item tinted list-row" id="data1">300</div>
                     <div class="finger-container">
-                        <img src="static/img/tap.png" class="finger" />
+                        <img src="static/img/tap.png" class="finger" alt="image indicating that items should be dragged with finger" />
                     </div>
                 </div>
             </div>

--- a/openday_scavenger/puzzles/demo/static/index.html
+++ b/openday_scavenger/puzzles/demo/static/index.html
@@ -2,6 +2,8 @@
 <html lang="en">
 
 <head>
+    <title>Demo Puzzle</title>
+
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="/static/js/htmx.min.js"></script>

--- a/openday_scavenger/puzzles/element/templates/index.html
+++ b/openday_scavenger/puzzles/element/templates/index.html
@@ -1,5 +1,6 @@
 {% set title = "🧈 " + location + " Element Quiz 🪨" %}
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>{{ title }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/openday_scavenger/puzzles/element/templates/popup.html
+++ b/openday_scavenger/puzzles/element/templates/popup.html
@@ -1,6 +1,6 @@
 <div id="element-popup" class="popup">
   <div class="popup-content">
-    <span class="close">&times;</span>
+    <span class="close">×</span>
     <h2 id="element-name" class="element-name"></h2>
 
     <div class="element-details-wrapper">

--- a/openday_scavenger/puzzles/finder/templates/hint_words.html
+++ b/openday_scavenger/puzzles/finder/templates/hint_words.html
@@ -1,4 +1,4 @@
-<div class = "hint-word-parent" id="hint-words">
+<div class="hint-word-parent" id="hint-words">
     {%for word in data['words']%}
         <div class="hint-word">{{word}}</div>
     {%endfor%}

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -1,5 +1,7 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
     <head>
+        <title>Hidden Treasure Puzzle</title>
         <meta content="width=device-width, initial-scale=1" name="viewport" />
         <script src="/static/js/htmx.min.js"></script>
         <script src="/static/js/json-enc.js"></script>
@@ -14,7 +16,6 @@
         <!-- custom styles -->
         <link href="static/styles.css" rel="stylesheet">
 
-
         <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
     </head>
     <body>
@@ -28,7 +29,7 @@
             <div class="row">
                 {% for j in range(data['puzzle'][i]|length) %}
                     {% set char = data['puzzle'][i][j] %}
-                     <div class="cell" data-is-in-word="0" data-selected="0" data-row="{{i}}" data-col="{{j}}" data-text= "{{char}}" id="{{i}}-{{j}}" name="char">{{char}}</div>
+                     <div class="cell" data-is-in-word="0" data-selected="0" data-row="{{i}}" data-col="{{j}}" data-text="{{char}}" id="{{i}}-{{j}}" name="char">{{char}}</div>
                 {%endfor%}
             </div>
             {% endfor %} 
@@ -38,7 +39,7 @@
         <button id="btn-hint" class="btn btn-outline-primary rounded-pill" data-hide="1">🤯 I need a hint!</button>
         <div class="form-parent">
             {% include 'found_words.html' %}
-            <div class = 'form-button-container'>
+            <div class='form-button-container'>
                 <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
                 <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
                 <!-- <input hidden type="text" id="answer" name="answer" > -->

--- a/openday_scavenger/puzzles/fourbyfour/templates/index.html
+++ b/openday_scavenger/puzzles/fourbyfour/templates/index.html
@@ -90,7 +90,6 @@
 
     {% endif %}
 
-
     {% if message and register_success %}
     <div class="alert alert-success text-center" role="alert">
         {{ message }}

--- a/openday_scavenger/puzzles/shuffleanagram/templates/index.html
+++ b/openday_scavenger/puzzles/shuffleanagram/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <title>Anagram Puzzle</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <!-- Bootstrap CSS -->
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">

--- a/openday_scavenger/puzzles/xray_filters/static/index.html
+++ b/openday_scavenger/puzzles/xray_filters/static/index.html
@@ -1,7 +1,8 @@
-<html>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+<!DOCTYPE html>
+<html lang="en">
     <head>
-        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <title>X-ray Filter Puzzle</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="/static/js/htmx.min.js"></script>
         <script src="/static/js/json-enc.js"></script>
 
@@ -107,8 +108,6 @@
                 <img src="static/beam_post_filter.png" alt="Beam2 post filter" class="beam2">
                 <img src="static/filters/ni_filter_02mm.png" alt="Filter1" class="filter-image filter1">
                 <img src="static/beam_post_filter.png" alt="Beam1 post filter" class="beam1">
-
-
             </div>
 
         <h3 id="output">Target attenuation: 0%</h3>

--- a/openday_scavenger/static/html/layout.html
+++ b/openday_scavenger/static/html/layout.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <title>Australian Synchrotron Open Day Scavenger Hunt</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/openday_scavenger/views/admin/templates/layout.html
+++ b/openday_scavenger/views/admin/templates/layout.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <title>Australian Synchrotron Open Day Scavenger Hunt :: Admin</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -16,8 +17,6 @@
     <link href="static/admin.css" rel="stylesheet" />
 
     <meta charset="utf-8" />
-    <!--It is necessary to use the UTF-8 encoding with plotly graphics to get e.g. negative signs to render correctly -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
     {% block header %}{% endblock %}
@@ -91,9 +90,9 @@
                             </a>
                         </li>
                     </ul>
-                    <img src="/static/images/logo.svg" class="mt-auto mb-3 d-none d-sm-block">
+                    <img src="/static/images/logo.svg" class="mt-auto mb-3 d-none d-sm-block" alt="ANSTO logo with text">
                     <img src="/static/images/logo-small.svg" class="mt-auto mb-3 ms-2 me-auto d-sm-none"
-                        style="width: 60px;">
+                        style="width: 60px;" alt="ANSTO logo">
                 </div>
             </aside>
             <div class="col py-3 admin-page-content">

--- a/openday_scavenger/views/admin/templates/map.html
+++ b/openday_scavenger/views/admin/templates/map.html
@@ -11,7 +11,6 @@
             map</a> for visitors!</small>
 </h1>
 
-
 <div class="my-4 mx-3 p-3 bg-body shadow-sm admin-panel-container">
     <h5 class="border-bottom pb-2 mb-0">Generate Puzzle Location String</h5>
 
@@ -39,7 +38,7 @@
     </div>
 
     <div id="map-editor" class="map-admin">
-        <img src="/static/images/map/as_layout.svg" class="map-svg" />
+        <img src="/static/images/map/as_layout.svg" class="map-svg" alt="puzzle map"/>
     </div>
 </div>
 

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -30,7 +30,6 @@
     <div id="puzzle-table" hx-get="/admin/puzzles/table" hx-trigger="load" hx-swap="innerHTML"></div>
 </div>
 
-
 <!-- Modal -->
 <div class="modal fade modal-lg" id="addPuzzleModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
@@ -78,7 +77,6 @@
         </div>
     </div>
 </div>
-
 
 <div class="modal fade modal-lg" id="uploadJsonModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">

--- a/openday_scavenger/views/admin/templates/qr.html
+++ b/openday_scavenger/views/admin/templates/qr.html
@@ -1,3 +1,3 @@
 <body>
-    <img src="{{ qr }}" width="500px" height="500px"/>
+    <img src="{{ qr }}" width="500px" height="500px" alt="QR code"/>
 </body>

--- a/openday_scavenger/views/admin/templates/visitors_pool.html
+++ b/openday_scavenger/views/admin/templates/visitors_pool.html
@@ -25,5 +25,4 @@
     </a>
 </div>
 
-
 {% endblock %}

--- a/openday_scavenger/views/game/static/index.html
+++ b/openday_scavenger/views/game/static/index.html
@@ -54,7 +54,6 @@
         Puzzle locks will only be within accessible areas!
     </p>
 
-
     <p class="text-secondary mt-5">Need some help finding puzzle locks?<br />
         <a href="/map">Use our map to see where all the puzzle locks are!</a>
     </p>
@@ -69,7 +68,7 @@
     </p>
 
     <div class="d-flex justify-content-center">
-        <img src="{{visitor_qr}}" width="50%" class="bg-white" style="margin-bottom: 150px; margin-top: 40px;" />
+        <img src="{{visitor_qr}}" width="50%" class="bg-white" style="margin-bottom: 150px; margin-top: 40px;" alt="QR code of adventure key" />
     </div>
     {% endif %}
 

--- a/openday_scavenger/views/game/static/layout.html
+++ b/openday_scavenger/views/game/static/layout.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <title>Australian Synchrotron Open Day Scavenger Hunt</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 

--- a/openday_scavenger/views/game/static/map.html
+++ b/openday_scavenger/views/game/static/map.html
@@ -23,9 +23,9 @@
     <div id="map-public" class="map-public">
         {% for marker in locations %}
         <img class="map-marker" src="/static/images/map/map_marker.svg" data-marker data-top="{{marker.top}}"
-            data-left="{{marker.left}}"></i>
+            data-left="{{marker.left}}" alt="puzzle lock location"></i>
         {% endfor %}
-        <img src="/static/images/map/as_layout.svg" class="map-svg" />
+        <img src="/static/images/map/as_layout.svg" class="map-svg" alt="puzzle locks map"/>
     </div>
 </div>
 

--- a/openday_scavenger/views/game/static/puzzle_completed.html
+++ b/openday_scavenger/views/game/static/puzzle_completed.html
@@ -29,7 +29,7 @@
     </p>
 
     <div class="d-flex justify-content-center">
-        <img src="{{visitor_qr}}" width="50%" class="bg-white" style="margin-bottom: 150px; margin-top: 40px;" />
+        <img src="{{visitor_qr}}" width="50%" class="bg-white" style="margin-bottom: 150px; margin-top: 40px;" alt="QR code of puzzle adventure key"/>
     </div>
     {% endif %}
 </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev-dependencies = [
     "pytest-mock>=3.14.0",
     "pytest>=8.3.3",
     "ruff>=0.6.4",
+    "djlint>=1.35.2"
 ]
 
 [tool.ruff]
@@ -61,3 +62,11 @@ source = ["openday_scavenger"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 60
+
+[tool.djlint]
+# TODO: Enforce viewport?
+# Just the 'critical' rules for now. At some point we can enable
+# the full rule set and maybe even enforce formatting of html/templates
+# like we do with python files 
+ignore="H030,H031,J004,H008,J018,H029,H006,H025,H021,T001,T002,T003"
+profile="jinja"

--- a/uv.lock
+++ b/uv.lock
@@ -105,6 +105,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cssbeautifier"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "jsbeautifier" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/66/9bfd2d69fb4479d38439076132a620972939f7949015563dce5e61d29a8b/cssbeautifier-1.15.1.tar.gz", hash = "sha256:9f7064362aedd559c55eeecf6b6bed65e05f33488dcbe39044f0403c26e1c006", size = 25673 }
+
+[[package]]
+name = "djlint"
+version = "1.35.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama" },
+    { name = "cssbeautifier" },
+    { name = "html-tag-names" },
+    { name = "html-void-elements" },
+    { name = "jsbeautifier" },
+    { name = "json5" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ee/ac8ee551ec04d5a214e62d008f40bf309574f103416482e03fb61fbad61c/djlint-1.35.2.tar.gz", hash = "sha256:318de9d4b9b0061a111f8f5164ecbacd8215f449dd4bd5a76d2a691c815ee103", size = 44684 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/31/297cad1a493f2910d366418acd0f33da908dfb8b16b8d6c6bafddac4fa7d/djlint-1.35.2-py3-none-any.whl", hash = "sha256:4ba995bad378f2afa77c8ea56ba1c14429d9ff26a18e8ae23bc71eedb9152243", size = 50641 },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -112,6 +145,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/37/7d/c871f55054e403fdf
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/a1/8c5287991ddb8d3e4662f71356d9656d91ab3a36618c3dd11b280df0d255/dnspython-2.6.1-py3-none-any.whl", hash = "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50", size = 307696 },
 ]
+
+[[package]]
+name = "editorconfig"
+version = "0.12.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/85/7b5c2fac7fdc37d959fab714b13b9acb75884490dcc0e8b1dc5e64105084/EditorConfig-0.12.4.tar.gz", hash = "sha256:24857fa1793917dd9ccf0c7810a07e05404ce9b823521c7dce22a4fb5d125f80", size = 13278 }
 
 [[package]]
 name = "email-validator"
@@ -216,6 +255,24 @@ wheels = [
 ]
 
 [[package]]
+name = "html-tag-names"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/7c/8c0dc3c5650036127fb4629d31cadf6cbdd57e21a77f9793fa8b2c8a3241/html-tag-names-0.1.2.tar.gz", hash = "sha256:04924aca48770f36b5a41c27e4d917062507be05118acb0ba869c97389084297", size = 15173 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/e4/242318dcaa06d8525ff72332fc15cea2cffb84c06cfc73c7da6c6b45801a/html_tag_names-0.1.2-py3-none-any.whl", hash = "sha256:eeb69ef21078486b615241f0393a72b41352c5219ee648e7c61f5632d26f0420", size = 15218 },
+]
+
+[[package]]
+name = "html-void-elements"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/5c/5f17d77256bf78ca98647517fadee50575e75d812daa01352c31d89d5bf2/html-void-elements-0.1.0.tar.gz", hash = "sha256:931b88f84cd606fee0b582c28fcd00e41d7149421fb673e1e1abd2f0c4f231f0", size = 14766 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/0a/373f28a1cf37f8c9aa23c82cbcac7197ddea95c88b5a3eaa564cdb8de375/html_void_elements-0.1.0-py3-none-any.whl", hash = "sha256:784cf39db03cdeb017320d9301009f8f3480f9d7b254d0974272e80e0cb5e0d2", size = 14889 },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -287,6 +344,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369", size = 240245 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d", size = 133271 },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/3e/dd37e1a7223247e3ef94714abf572415b89c4e121c4af48e9e4c392e2ca0/jsbeautifier-1.15.1.tar.gz", hash = "sha256:ebd733b560704c602d744eafc839db60a1ee9326e30a2a80c4adb8718adc1b24", size = 75606 }
+
+[[package]]
+name = "json5"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/59/51b032d53212a51f17ebbcc01bd4217faab6d6c09ed0d856a987a5f42bbc/json5-0.9.25.tar.gz", hash = "sha256:548e41b9be043f9426776f05df8635a00fe06104ea51ed24b67f908856e151ae", size = 40332 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/3c/4f8791ee53ab9eeb0b022205aa79387119a74cc9429582ce04098e6fc540/json5-0.9.25-py3-none-any.whl", hash = "sha256:34ed7d834b1341a86987ed52f3f76cd8ee184394906b6e22a1e0deb9ab294e8f", size = 30109 },
 ]
 
 [[package]]
@@ -428,6 +504,7 @@ postgres = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "djlint" },
     { name = "mypy" },
     { name = "pyright" },
     { name = "pytest" },
@@ -456,6 +533,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.6.1" },
+    { name = "djlint", specifier = ">=1.35.2" },
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "pyright", specifier = ">=1.1.379" },
     { name = "pytest", specifier = ">=8.3.3" },
@@ -506,6 +584,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
     { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
     { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
 ]
 
 [[package]]
@@ -764,6 +851,44 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2024.9.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/38/148df33b4dbca3bd069b963acab5e0fa1a9dbd6820f8c322d0dd6faeff96/regex-2024.9.11.tar.gz", hash = "sha256:6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd", size = 399403 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/92/407531450762bed778eedbde04407f68cbd75d13cee96c6f8d6903d9c6c1/regex-2024.9.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b0d0a6c64fcc4ef9c69bd5b3b3626cc3776520a1637d8abaa62b9edc147a58f7", size = 483590 },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/048acbc5ae1f615adc6cba36cc45734e679b5f1e4e58c3c77f0ed611d4e2/regex-2024.9.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:49b0e06786ea663f933f3710a51e9385ce0cba0ea56b67107fd841a55d56a231", size = 288175 },
+    { url = "https://files.pythonhosted.org/packages/8a/ea/909d8620329ab710dfaf7b4adee41242ab7c9b95ea8d838e9bfe76244259/regex-2024.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5b513b6997a0b2f10e4fd3a1313568e373926e8c252bd76c960f96fd039cd28d", size = 284749 },
+    { url = "https://files.pythonhosted.org/packages/ca/fa/521eb683b916389b4975337873e66954e0f6d8f91bd5774164a57b503185/regex-2024.9.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee439691d8c23e76f9802c42a95cfeebf9d47cf4ffd06f18489122dbb0a7ad64", size = 795181 },
+    { url = "https://files.pythonhosted.org/packages/28/db/63047feddc3280cc242f9c74f7aeddc6ee662b1835f00046f57d5630c827/regex-2024.9.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8f877c89719d759e52783f7fe6e1c67121076b87b40542966c02de5503ace42", size = 835842 },
+    { url = "https://files.pythonhosted.org/packages/e3/94/86adc259ff8ec26edf35fcca7e334566c1805c7493b192cb09679f9c3dee/regex-2024.9.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23b30c62d0f16827f2ae9f2bb87619bc4fba2044911e2e6c2eb1af0161cdb766", size = 823533 },
+    { url = "https://files.pythonhosted.org/packages/29/52/84662b6636061277cb857f658518aa7db6672bc6d1a3f503ccd5aefc581e/regex-2024.9.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ab7824093d8f10d44330fe1e6493f756f252d145323dd17ab6b48733ff6c0a", size = 797037 },
+    { url = "https://files.pythonhosted.org/packages/c3/2a/cd4675dd987e4a7505f0364a958bc41f3b84942de9efaad0ef9a2646681c/regex-2024.9.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8dee5b4810a89447151999428fe096977346cf2f29f4d5e29609d2e19e0199c9", size = 784106 },
+    { url = "https://files.pythonhosted.org/packages/6f/75/3ea7ec29de0bbf42f21f812f48781d41e627d57a634f3f23947c9a46e303/regex-2024.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98eeee2f2e63edae2181c886d7911ce502e1292794f4c5ee71e60e23e8d26b5d", size = 782468 },
+    { url = "https://files.pythonhosted.org/packages/d3/67/15519d69b52c252b270e679cb578e22e0c02b8dd4e361f2b04efcc7f2335/regex-2024.9.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:57fdd2e0b2694ce6fc2e5ccf189789c3e2962916fb38779d3e3521ff8fe7a822", size = 790324 },
+    { url = "https://files.pythonhosted.org/packages/9c/71/eff77d3fe7ba08ab0672920059ec30d63fa7e41aa0fb61c562726e9bd721/regex-2024.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d552c78411f60b1fdaafd117a1fca2f02e562e309223b9d44b7de8be451ec5e0", size = 860214 },
+    { url = "https://files.pythonhosted.org/packages/81/11/e1bdf84a72372e56f1ea4b833dd583b822a23138a616ace7ab57a0e11556/regex-2024.9.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a0b2b80321c2ed3fcf0385ec9e51a12253c50f146fddb2abbb10f033fe3d049a", size = 859420 },
+    { url = "https://files.pythonhosted.org/packages/ea/75/9753e9dcebfa7c3645563ef5c8a58f3a47e799c872165f37c55737dadd3e/regex-2024.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:18406efb2f5a0e57e3a5881cd9354c1512d3bb4f5c45d96d110a66114d84d23a", size = 787333 },
+    { url = "https://files.pythonhosted.org/packages/bc/4e/ba1cbca93141f7416624b3ae63573e785d4bc1834c8be44a8f0747919eca/regex-2024.9.11-cp312-cp312-win32.whl", hash = "sha256:e464b467f1588e2c42d26814231edecbcfe77f5ac414d92cbf4e7b55b2c2a776", size = 262058 },
+    { url = "https://files.pythonhosted.org/packages/6e/16/efc5f194778bf43e5888209e5cec4b258005d37c613b67ae137df3b89c53/regex-2024.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:9e8719792ca63c6b8340380352c24dcb8cd7ec49dae36e963742a275dfae6009", size = 273526 },
+    { url = "https://files.pythonhosted.org/packages/93/0a/d1c6b9af1ff1e36832fe38d74d5c5bab913f2bdcbbd6bc0e7f3ce8b2f577/regex-2024.9.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c157bb447303070f256e084668b702073db99bbb61d44f85d811025fcf38f784", size = 483376 },
+    { url = "https://files.pythonhosted.org/packages/a4/42/5910a050c105d7f750a72dcb49c30220c3ae4e2654e54aaaa0e9bc0584cb/regex-2024.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4db21ece84dfeefc5d8a3863f101995de646c6cb0536952c321a2650aa202c36", size = 288112 },
+    { url = "https://files.pythonhosted.org/packages/8d/56/0c262aff0e9224fa7ffce47b5458d373f4d3e3ff84e99b5ff0cb15e0b5b2/regex-2024.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:220e92a30b426daf23bb67a7962900ed4613589bab80382be09b48896d211e92", size = 284608 },
+    { url = "https://files.pythonhosted.org/packages/b9/54/9fe8f9aec5007bbbbce28ba3d2e3eaca425f95387b7d1e84f0d137d25237/regex-2024.9.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb1ae19e64c14c7ec1995f40bd932448713d3c73509e82d8cd7744dc00e29e86", size = 795337 },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/6b2f642c3cded271c4f16cc4daa7231be544d30fe2b168e0223724b49a61/regex-2024.9.11-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f47cd43a5bfa48f86925fe26fbdd0a488ff15b62468abb5d2a1e092a4fb10e85", size = 835848 },
+    { url = "https://files.pythonhosted.org/packages/cd/9e/187363bdf5d8c0e4662117b92aa32bf52f8f09620ae93abc7537d96d3311/regex-2024.9.11-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9d4a76b96f398697fe01117093613166e6aa8195d63f1b4ec3f21ab637632963", size = 823503 },
+    { url = "https://files.pythonhosted.org/packages/f8/10/601303b8ee93589f879664b0cfd3127949ff32b17f9b6c490fb201106c4d/regex-2024.9.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ea51dcc0835eea2ea31d66456210a4e01a076d820e9039b04ae8d17ac11dee6", size = 797049 },
+    { url = "https://files.pythonhosted.org/packages/ef/1c/ea200f61ce9f341763f2717ab4daebe4422d83e9fd4ac5e33435fd3a148d/regex-2024.9.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7aaa315101c6567a9a45d2839322c51c8d6e81f67683d529512f5bcfb99c802", size = 784144 },
+    { url = "https://files.pythonhosted.org/packages/d8/5c/d2429be49ef3292def7688401d3deb11702c13dcaecdc71d2b407421275b/regex-2024.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c57d08ad67aba97af57a7263c2d9006d5c404d721c5f7542f077f109ec2a4a29", size = 782483 },
+    { url = "https://files.pythonhosted.org/packages/12/d9/cbc30f2ff7164f3b26a7760f87c54bf8b2faed286f60efd80350a51c5b99/regex-2024.9.11-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f8404bf61298bb6f8224bb9176c1424548ee1181130818fcd2cbffddc768bed8", size = 790320 },
+    { url = "https://files.pythonhosted.org/packages/19/1d/43ed03a236313639da5a45e61bc553c8d41e925bcf29b0f8ecff0c2c3f25/regex-2024.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dd4490a33eb909ef5078ab20f5f000087afa2a4daa27b4c072ccb3cb3050ad84", size = 860435 },
+    { url = "https://files.pythonhosted.org/packages/34/4f/5d04da61c7c56e785058a46349f7285ae3ebc0726c6ea7c5c70600a52233/regex-2024.9.11-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:eee9130eaad130649fd73e5cd92f60e55708952260ede70da64de420cdcad554", size = 859571 },
+    { url = "https://files.pythonhosted.org/packages/12/7f/8398c8155a3c70703a8e91c29532558186558e1aea44144b382faa2a6f7a/regex-2024.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a2644a93da36c784e546de579ec1806bfd2763ef47babc1b03d765fe560c9f8", size = 787398 },
+    { url = "https://files.pythonhosted.org/packages/58/3a/f5903977647a9a7e46d5535e9e96c194304aeeca7501240509bde2f9e17f/regex-2024.9.11-cp313-cp313-win32.whl", hash = "sha256:e997fd30430c57138adc06bba4c7c2968fb13d101e57dd5bb9355bf8ce3fa7e8", size = 262035 },
+    { url = "https://files.pythonhosted.org/packages/ff/80/51ba3a4b7482f6011095b3a036e07374f64de180b7d870b704ed22509002/regex-2024.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:042c55879cfeb21a8adacc84ea347721d3d83a159da6acdf1116859e2427c43f", size = 273510 },
+]
+
+[[package]]
 name = "reportlab"
 version = "4.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -890,6 +1015,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.66.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/5d/acf5905c36149bbaec41ccf7f2b68814647347b72075ac0b1fe3022fdc73/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", size = 78351 },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:
- Add basic linting to HTML templates
- Fix up low hanging fruit
- Enforce linting at build time

Future work:
- We probably want to make our titles consistent somehow (e.g. the layout template automatically sets the title to the puzzle name or something like that)
- djlint can format HTML/templates and enforce the formatting. Probably not a good idea to format everything on the Friday before open day but might be nice in the future
