### PR TITLE
Bulk JSON upload: Prevent crash if ID isn't in database

### DIFF
--- a/openday_scavenger/api/puzzles/service.py
+++ b/openday_scavenger/api/puzzles/service.py
@@ -546,7 +546,7 @@ def upsert_puzzle_json(db_session: Session, puzzle_json: PuzzleJson):
     existing_puzzles_by_id = {item.id: item for item in get_all(db_session)}
 
     for puzzle in puzzle_json.puzzles:
-        existing_puzzle = "id" in puzzle and existing_puzzles_by_id[puzzle["id"]]
+        existing_puzzle = "id" in puzzle and existing_puzzles_by_id.get(puzzle["id"])
         if existing_puzzle:
             _ = update(db_session, existing_puzzle.name, PuzzleUpdate(**puzzle))
         else:


### PR DESCRIPTION
I'm new to Python and didn't realise that accessing a dict with the `[]` syntax will throw if the key doesn't exist. `get` will return `None` if the key doesn't exist which will be handled below