### PR TITLE
Bulk JSON upload: Honour the IDs in the uploaded files on create

### DIFF
--- a/openday_scavenger/api/puzzles/schemas.py
+++ b/openday_scavenger/api/puzzles/schemas.py
@@ -6,6 +6,7 @@ from openday_scavenger.api.visitors.schemas import VisitorAuth
 
 
 class PuzzleCreate(BaseModel):
+    id: int | None = None
     name: str
     answer: str
     active: bool = False

--- a/openday_scavenger/api/puzzles/service.py
+++ b/openday_scavenger/api/puzzles/service.py
@@ -193,6 +193,7 @@ def create(db_session: Session, puzzle_in: PuzzleCreate) -> Puzzle:
     # explicitly. This maintains a nice abstraction between the service layer
     # and the database layer.
     puzzle = Puzzle(
+        id=puzzle_in.id,
         name=puzzle_in.name,
         answer=puzzle_in.answer,
         active=puzzle_in.active,


### PR DESCRIPTION
- Before this change, if the uploaded JSON file had IDs and an entity didn't exist yet it would create the entity with fresh generated ID
- Then if you made a change to the JSON file and uploaded again, it would crash because the IDs in the file didn't match what was in the DB
- This allows an entity to be created (optionally!) with a specific ID to prevent this issue