### PR TITLE
FIxed Wordsearch Successful Submission Page Heading Bug

### DIFF
--- a/openday_scavenger/puzzles/finder/static/demo.css
+++ b/openday_scavenger/puzzles/finder/static/demo.css
@@ -1,3 +1,0 @@
-body {
-    background-color: LightSteelBlue;
-}

--- a/openday_scavenger/puzzles/finder/static/js/index.js
+++ b/openday_scavenger/puzzles/finder/static/js/index.js
@@ -145,31 +145,12 @@ function extractChar(total, value, index, array) {
   return total + value["char"];
 }
 
- const submitForm = async () => {
-  const name = document.getElementById("name");
-  const visitor = document.getElementById("visitor");
+function updateAnswer() {
   const words = getCachedSession("words") ;// JSON.parse(sessionStorage.getItem("words"));
   const answer = words.map(item=> item['word'].toLowerCase());
-  answer.sort();
-  // Construct a FormData instance
-  const formData = new FormData();
-  const path = window.location.pathname;
-  // Add a text field
-  formData.append("name", name.defaultValue);
-  formData.append("visitor", visitor.defaultValue);
-  formData.append("answer", answer.join()); // join with comma
 
-  try {
-    const response = await fetch(`/submission`, {
-      method: "POST",
-      // Set the FormData instance as the request body
-      body: formData,
-    });
-    const html = await response.text();
-    document.body.innerHTML = html;
-  } catch (e) {
-    console.error(e);
-  }
+  // Update hidden answer field
+  document.getElementById("answer").value = answer.sort().join();
 };
 
 
@@ -198,6 +179,9 @@ function extractChar(total, value, index, array) {
 
     // after adding the char_list into words, should empty the char_list
     saveSession("char_list",[]);//sessionStorage.setItem("char_list",JSON.stringify([]));
+
+    // Update the hidden answer input
+    updateAnswer();
   }
 }
 
@@ -290,9 +274,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     const btnAdd = document.getElementById("btn-add");
     btnAdd.addEventListener("click", onClickAddWord);
-
-    const btnSubmit =document.getElementById("btn-submit");
-    btnSubmit.addEventListener("click", submitForm); 
 
     const btnHint =document.getElementById("btn-hint");
     btnHint.addEventListener("click", displayHideHint ); 

--- a/openday_scavenger/puzzles/finder/static/styles.css
+++ b/openday_scavenger/puzzles/finder/static/styles.css
@@ -210,7 +210,6 @@ body {
     }
     .found-words {
         gap: 2px;
-        margin-bottom : 5px
     }
     .hint-word-parent {
         gap: 2px;

--- a/openday_scavenger/puzzles/finder/static/styles.css
+++ b/openday_scavenger/puzzles/finder/static/styles.css
@@ -193,7 +193,7 @@ h1 {
         /* flex-basis: 0;
         flex-grow: 1;
         flex-shrink: 1; */
-        padding: 0rem;
+        padding: 0.5rem;
         border: 0.8px none grey;
     }
     .btn {

--- a/openday_scavenger/puzzles/finder/static/styles.css
+++ b/openday_scavenger/puzzles/finder/static/styles.css
@@ -17,7 +17,7 @@ body {
 }
 
 /* Style for the header */
-h1 {
+.heading-h1 {
     background-color: #203d79;
     color: #ffffff;
     padding: 10px 0;
@@ -223,7 +223,7 @@ h1 {
     .word-text {
         font-size: calc(0.5rem + .9vw);
     }
-    h1 {
+    .heading-h1 {
         font-size: calc(1rem + .9vw);
         padding: 5px;
         line-height: 1;

--- a/openday_scavenger/puzzles/finder/static/styles.css
+++ b/openday_scavenger/puzzles/finder/static/styles.css
@@ -17,7 +17,7 @@ body {
 }
 
 /* Style for the header */
-.heading-h1 {
+.h1 {
     background-color: #203d79;
     color: #ffffff;
     padding: 10px 0;
@@ -222,7 +222,7 @@ body {
     .word-text {
         font-size: calc(0.5rem + .9vw);
     }
-    .heading-h1 {
+    .h1 {
         font-size: calc(1rem + .9vw);
         padding: 5px;
         line-height: 1;

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -43,16 +43,24 @@
 
     {% include 'hint_words.html' %}
     <button id="btn-hint" class="btn btn-outline-primary rounded-pill" data-hide="1">🤯 I need a hint!</button>
+
     <div class="form-parent">
         {% include 'found_words.html' %}
         <div class='form-button-container'>
-            <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
-            <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
-            <!-- <input hidden type="text" id="answer" name="answer" > -->
-            <button id="btn-add" class="btn btn-outline-primary rounded-pill mx-2"><i class="fa-solid fa-plus"></i> Add
-                to answer</button>
-            <button id="btn-submit" class="btn btn-outline-primary rounded-pill mx-2"><i class="fa-solid fa-check"></i>
-                Submit!</button>
+            <button id="btn-add" class="btn btn-outline-primary rounded-pill mx-2" type="button">
+                <i class="fa-solid fa-plus"></i> Add
+                to answer
+            </button>
+
+            <form id="form" method="POST" action="/submission" class="d-flex">
+                <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
+                <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
+                <input hidden type="text" id="answer" name="answer">
+                <button class="btn btn-outline-primary rounded-pill mx-2 w-100">
+                    <i class="fa-solid fa-check"></i>
+                    Submit!
+                </button>
+            </form>
         </div>
     </div>
 </body>

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -25,7 +25,7 @@
 
 <body>
     <!-- <h1>Finder Puzzle</h1> -->
-    <h1 id="question"> 🔍 Can you find the hidden treasure? </h1>
+    <h1 id="question" class="heading-h1"> 🔍 Can you find the hidden treasure? </h1>
     <h2 id="question">{{question}} </h2>
     <h5 id="hint" data-num="{{data['words']|length}}"> Select letters in order to build a word. 😎</h5>
     <h5>😏 Use the button below to add words to your answer! 👇</h5>

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -25,7 +25,7 @@
 
 <body>
     <!-- <h1>Finder Puzzle</h1> -->
-    <h1 id="question" class="heading-h1"> 🔍 Can you find the hidden treasure? </h1>
+    <h1> 🔍 Can you find the hidden treasure? </h1>
     <h2 id="question">{{question}} </h2>
     <h5 id="hint" data-num="{{data['words']|length}}"> Select letters in order to build a word. 😎</h5>
     <h5>😏 Use the button below to add words to your answer! 👇</h5>

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -1,54 +1,60 @@
-<html>
-    <head>
-        <meta content="width=device-width, initial-scale=1" name="viewport" />
-        <script src="/static/js/htmx.min.js"></script>
-        <script src="/static/js/json-enc.js"></script>
-        <script src="/static/js/bootstrap.bundle.min.js"></script>
-        <script src="/static/js/html5-qrcode.js"></script>
-        <link href="/static/css/fontawesome.min.css" rel="stylesheet" />
-        <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-        <link href="/static/css/solid.min.css" rel="stylesheet"/>
+<!DOCTYPE html>
+<html lang="en">
 
-        <!-- custom scripts -->
-        <script src="static/js/index.js"></script>
-        <!-- custom styles -->
-        <link href="static/styles.css" rel="stylesheet">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
 
+    <title>Hidden Treasure Wordsearch</title>
+    <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
 
-        <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
-    </head>
-    <body>
-        <!-- <h1>Finder Puzzle</h1> -->
-        <h1 id="question" > 🔍 Can you find the hidden treasure? </h1>
-        <h2 id="question" >{{question}} </h2>
-        <h5 id="hint" data-num="{{data['words']|length}}"> Select letters in order to build a word. 😎</h5>
-        <h5>😏 Use the button below to add words to your answer! 👇</h5>
-        <div class="container" style="margin-top:15px;">
-            {% for i in range(data['puzzle']|length ) %}
-            <div class="row">
-                {% for j in range(data['puzzle'][i]|length) %}
-                    {% set char = data['puzzle'][i][j] %}
-                     <div class="cell" data-is-in-word="0" data-selected="0" data-row="{{i}}" data-col="{{j}}" data-text= "{{char}}" id="{{i}}-{{j}}" name="char">{{char}}</div>
-                {%endfor%}
-            </div>
-            {% endfor %} 
+    <script src="/static/js/htmx.min.js"></script>
+    <script src="/static/js/json-enc.js"></script>
+    <script src="/static/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/js/html5-qrcode.js"></script>
+
+    <link href="/static/css/fontawesome.min.css" rel="stylesheet" />
+    <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/css/solid.min.css" rel="stylesheet" />
+
+    <!-- custom scripts -->
+    <script src="static/js/index.js"></script>
+    <!-- custom styles -->
+    <link href="static/styles.css" rel="stylesheet">
+</head>
+
+<body>
+    <!-- <h1>Finder Puzzle</h1> -->
+    <h1 id="question"> 🔍 Can you find the hidden treasure? </h1>
+    <h2 id="question">{{question}} </h2>
+    <h5 id="hint" data-num="{{data['words']|length}}"> Select letters in order to build a word. 😎</h5>
+    <h5>😏 Use the button below to add words to your answer! 👇</h5>
+    <div class="container" style="margin-top:15px;">
+        {% for i in range(data['puzzle']|length ) %}
+        <div class="row">
+            {% for j in range(data['puzzle'][i]|length) %}
+            {% set char = data['puzzle'][i][j] %}
+            <div class="cell" data-is-in-word="0" data-selected="0" data-row="{{i}}" data-col="{{j}}"
+                data-text="{{char}}" id="{{i}}-{{j}}" name="char">{{char}}</div>
+            {%endfor%}
         </div>
-        
-        {% include 'hint_words.html' %}
-        <button id="btn-hint" class="btn btn-outline-primary rounded-pill" data-hide="1">🤯 I need a hint!</button>
-        <div class="form-parent">
-            {% include 'found_words.html' %}
-            <div class = 'form-button-container'>
-                <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
-                <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
-                <!-- <input hidden type="text" id="answer" name="answer" > -->
-                <button id="btn-add" class="btn btn-outline-primary rounded-pill mx-2" ><i class="fa-solid fa-plus"></i>  Add to answer</button>
-                <button id="btn-submit" class="btn btn-outline-primary rounded-pill mx-2"><i class="fa-solid fa-check"></i> Submit!</button>
-                    
-            </div>
-        </div>
-        
+        {% endfor %}
+    </div>
 
-        
-    </body>
+    {% include 'hint_words.html' %}
+    <button id="btn-hint" class="btn btn-outline-primary rounded-pill" data-hide="1">🤯 I need a hint!</button>
+    <div class="form-parent">
+        {% include 'found_words.html' %}
+        <div class='form-button-container'>
+            <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
+            <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
+            <!-- <input hidden type="text" id="answer" name="answer" > -->
+            <button id="btn-add" class="btn btn-outline-primary rounded-pill mx-2"><i class="fa-solid fa-plus"></i> Add
+                to answer</button>
+            <button id="btn-submit" class="btn btn-outline-primary rounded-pill mx-2"><i class="fa-solid fa-check"></i>
+                Submit!</button>
+        </div>
+    </div>
+</body>
+
 </html>


### PR DESCRIPTION
The clash was happening because the style applied on h1 was being using on the submission page somehow.

I moved it into its own css class `.heading-h1` so it doesn't apply directly to `h1`, so this should fix it. But I can't test this locally because the word-search-generator package doesn't work for me, so if you could double check and test that @stmudie that would be great! 🙏

I also bumped the padding on mobile around the letters so there's more space to tap each letter without accidentally tapping the letters next to it.