### PR TITLE
Linting: Make HTML attribute quoting consistent

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,8 @@ on:
 jobs:
   test:
     name: test-lint-format
-    runs-on: ubuntu-latest
+    # ubuntu-24.04 (latest) fails at the install step due to missing libjpeg
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/openday_scavenger/puzzles/ads_question_answer_matchup/static/index.html
+++ b/openday_scavenger/puzzles/ads_question_answer_matchup/static/index.html
@@ -23,7 +23,7 @@
 <body>
     <h1>ADS Question Answer Matchup Puzzle</h1>
 
-    <form id='form' method='POST' action='/submission'>
+    <form id="form" method="POST" action="/submission">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <input hidden type="text" id="answer" name="answer">
         <div class="container-lg">

--- a/openday_scavenger/puzzles/ant/static/index.html
+++ b/openday_scavenger/puzzles/ant/static/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="/static/js/htmx.min.js"></script>
         <script src="/static/js/json-enc.js"></script>
-        
+
         <link href="static/styles.css" rel="stylesheet">
         <script src="static/js/index.js"></script>
         <link id="favicon" rel="icon" type="image/x-icon" href="/static/favicon.ico">
@@ -15,49 +15,42 @@
         <!-- <h1>Demo Puzzle</h1> -->
         <div class="container">
             <h1 class="title">Look inside the ant! 🐜</h1>
-         
+
             <div class="instructions">
-             <p>This is a video showing an example of the reconstructed CT data of an ant taken at the Micro Computed Tomography (MCT) beamline. MCT can take three-dimensional (3D) structures at high spatial resolution, which can get down to micron scales. 
+             <p>This is a video showing an example of the reconstructed CT data of an ant taken at the Micro Computed Tomography (MCT) beamline. MCT can take three-dimensional (3D) structures at high spatial resolution, which can get down to micron scales.
                 One micron is a thousandth of a millimeter. For comparison, a water droplet in mist or cloud is around 10 microns. Do you know what the resolution is for MCT?👀 Select your answer at the bottom of this page!</p>
             </div>
 
            <hr class="solid">
-           
+
            <video width="100%"  controls loop>
                 <source src="static/ant_movieph.mp4" type="video/mp4">
                 Your browser does not support HTML video.
             </video>
-           
+
            <hr class="solid">
-           
-           <form id='form' class="form" method='POST' action='/submission'>
+
+           <form id="form" class="form" method="POST" action="/submission">
                 <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
                 <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
                 <input hidden id="answer" name="answer" class="form-input">
                 <div class="container">
-                    
                     <input type="radio" id="option-a" class="form-option" name="resolution" value="0.1">
                     <label class="form-option-label" for="option-a">0.1 micron</label>
- 
-                    
+
                     <input type="radio" id="option-b" class="form-option" name="resolution"  value="1">
                     <label class="form-option-label" for="option-b">1 micron</label>
-                    
-                    
+
                     <input type="radio" id="option-c" class="form-option" name="resolution" value="10">
                     <label class="form-option-label" for="option-c">10 micron</label>
-                    
-                    
+
                     <input type="radio" id="option-d" class="form-option" name="resolution" value="100">
                     <label class="form-option-label" for="option-d">100 micron</label>
-                    
                 </div>
-                
+
                 <!-- <input type="text" id="answer" name="answer"> -->
                 <button class="form-button" type="submit">✈ Submit</button>
             </form>
          </div>
-         
-        
     </body>
 </html>

--- a/openday_scavenger/puzzles/demo/static/index.html
+++ b/openday_scavenger/puzzles/demo/static/index.html
@@ -18,7 +18,7 @@
 
     What energy in GeV does the accelerator of the Australian Synchrotron run at?
 
-    <form id='form' method='POST' action='/submission'>
+    <form id="form" method="POST" action="/submission">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <label for="energy">Energy:</label><br>
         <input type="text" id="answer" name="answer">

--- a/openday_scavenger/puzzles/finder/templates/index.html
+++ b/openday_scavenger/puzzles/finder/templates/index.html
@@ -46,7 +46,7 @@
 
     <div class="form-parent">
         {% include 'found_words.html' %}
-        <div class='form-button-container'>
+        <div class="form-button-container">
             <button id="btn-add" class="btn btn-outline-primary rounded-pill mx-2" type="button">
                 <i class="fa-solid fa-plus"></i> Add
                 to answer

--- a/openday_scavenger/puzzles/imagereveal/static/index.html
+++ b/openday_scavenger/puzzles/imagereveal/static/index.html
@@ -28,7 +28,7 @@
         </div>
 
         {% if state['complete'] == false %}
-        <form id='form' class="d-flex flex-column text-center justify-content-center" method='POST'
+        <form id="form" class="d-flex flex-column text-center justify-content-center" method="POST"
             action='/puzzles/imagereveal/partsubmission'>
             <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
             <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
@@ -90,7 +90,7 @@
 
         {% else %}
 
-        <form id='auto-submit-form' method='POST' action='/submission'
+        <form id="auto-submit-form" method="POST" action="/submission"
             class="d-flex flex-column text-center justify-content-center">
             <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
             <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">

--- a/openday_scavenger/puzzles/labelthemap/templates/index.html
+++ b/openday_scavenger/puzzles/labelthemap/templates/index.html
@@ -51,7 +51,7 @@
         </div>
     </div>
 
-    <form id='form' method='POST' action='/submission' class="text-center">
+    <form id="form" method="POST" action="/submission" class="text-center">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
         <input hidden type="text" id="answer" name="answer" value="">

--- a/openday_scavenger/puzzles/shuffleanagram/templates/index.html
+++ b/openday_scavenger/puzzles/shuffleanagram/templates/index.html
@@ -28,7 +28,7 @@
         </button>
     </div>
 
-    <form id='form' method='POST' action='/submission' class="text-center">
+    <form id="form" method="POST" action="/submission" class="text-center">
         <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
         <div class="form-group mb-1">
             <label for="raw-answer">Your answer:</label><br>

--- a/openday_scavenger/puzzles/xray_filters/static/index.html
+++ b/openday_scavenger/puzzles/xray_filters/static/index.html
@@ -113,7 +113,7 @@
         <h3 id="output">Target attenuation: 0%</h3>
 
         <div class="checkbox-container">
-            <form id='form' method='POST' action='/submission'>
+            <form id="form" method="POST" action="/submission">
                 <input hidden type="text" id="name" name="name" value="{{ puzzle }}">
                 <input hidden type="text" id="visitor" name="visitor" value="{{ visitor }}">
                 <input hidden type="text" id="answer" name="answer">

--- a/openday_scavenger/views/admin/templates/puzzles.html
+++ b/openday_scavenger/views/admin/templates/puzzles.html
@@ -38,7 +38,7 @@
                 <h1 class="modal-title fs-5">Add a new Puzzle to the Scavenger Hunt</h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <form id='puzzle-add-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/puzzles'
+            <form id="puzzle-add-form" class="mt-3" hx-encoding="multipart/form-data" hx-post="/admin/puzzles"
                 hx-ext='json-enc' hx-swap="innerHTML" hx-target="#puzzle-table">
                 <div class="modal-body">
                     <div class="container">
@@ -85,7 +85,7 @@
                 <h1 class="modal-title fs-5">Upload a JSON file with puzzle data</h1>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <form id='upload-json-form' class="mt-3" hx-encoding='multipart/form-data'
+            <form id="upload-json-form" class="mt-3" hx-encoding="multipart/form-data"
                 hx-post='/admin/puzzles/upload-json' hx-swap="innerHTML" hx-target="#puzzle-table">
                 <div class="modal-body">
                     <div class="container">

--- a/openday_scavenger/views/admin/templates/puzzles_edit_modal.html
+++ b/openday_scavenger/views/admin/templates/puzzles_edit_modal.html
@@ -4,7 +4,7 @@
         <h1 class="modal-title fs-5">Edit Puzzle</h1>
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
-      <form id='puzzle-edit-form' class="mt-3" hx-encoding='multipart/form-data' hx-put='/admin/puzzles/{{ puzzle.name }}' hx-ext='json-enc' hx-swap="innerHTML" hx-target="#puzzle-table">
+      <form id="puzzle-edit-form" class="mt-3" hx-encoding="multipart/form-data" hx-put="/admin/puzzles/{{ puzzle.name }}" hx-ext="json-enc" hx-swap="innerHTML" hx-target="#puzzle-table">
           <div class="modal-body">
               <div class="container">
                   <div class="row">
@@ -13,19 +13,19 @@
                               <label for="name" class="form-label">Name:</label>
                               <input type="text" id="inputName" name="name" class="form-control" value="{{ puzzle.name }}">
                           </div>
-                          
+
                           <div class="mb-3">
                               <label for="name" class="form-label">Location:</label>
                               <input type="text" id="inputLocation" name="location" class="form-control" value="{{ puzzle.location }}">
                           </div>
                       </div>
-                      
+
                       <div class="col">
                           <div class="mb-3">
                               <label for="name" class="form-label">Answer:</label>
                               <input type="text" id="inputAnswer" name="answer" class="form-control" value="{{ puzzle.answer }}">
                           </div>
-  
+
                           <div class="mb-3">
                               <label for="name" class="form-label">Notes:</label>
                               <input type="text" id="inputNotes" name="notes" class="form-control" value="{{ puzzle.notes }}">

--- a/openday_scavenger/views/admin/templates/responses.html
+++ b/openday_scavenger/views/admin/templates/responses.html
@@ -8,7 +8,7 @@
 
 <div class="my-4 mx-3 p-3 bg-body shadow-sm admin-panel-container">
     <h5 class="border-bottom pb-2 mb-0">Responses</h5>
-    <form id='visitor-filter-form' class="mt-3" hx-include="[name='puzzle_name'],[name='visitor_uid']"> 
+    <form id="visitor-filter-form" class="mt-3" hx-include="[name='puzzle_name'],[name='visitor_uid']">
         <div class="mb-3">
             <label for="puzzle_name" class="form-label">Filter by Puzzle Name:</label>
             <input type="text" id="puzzle_name" name="puzzle_name" class="form-control" hx-trigger="keyup changed delay:500ms" hx-get='/admin/responses/table' hx-swap="innerHTML" hx-target="#response-table">

--- a/openday_scavenger/views/admin/templates/visitors.html
+++ b/openday_scavenger/views/admin/templates/visitors.html
@@ -14,7 +14,7 @@
             </div>
         </div>
         <div class="col-8">
-            <div class="bg-body shadow-sm admin-panel-container" hx-encoding='multipart/form-data' hx-trigger="load, input from:#uid_filter delay:500ms, input from:#still_playing, click from:#clearButton" hx-include="#uid_filter,#still_playing" hx-get='/admin/visitors/status'>
+            <div class="bg-body shadow-sm admin-panel-container" hx-encoding="multipart/form-data" hx-trigger="load, input from:#uid_filter delay:500ms, input from:#still_playing, click from:#clearButton" hx-include="#uid_filter,#still_playing" hx-get="/admin/visitors/status">
                 <div class="me-3 p-3">
                     Please scan an Adventure Key or type the visitor UID into the search field.
                 </div>
@@ -26,7 +26,7 @@
 
 <div class="my-4 mx-3 p-3 bg-body shadow-sm admin-panel-container">
     <h5 class="border-bottom pb-2 mb-0">Visitors</h5>
-    <form id='visitor-filter-form' class="mt-3" onsubmit="return false;" hx-encoding='multipart/form-data' hx-trigger="load, input from:#uid_filter delay:500ms, input from:#still_playing, click from:#clearButton" hx-get='/admin/visitors/table' hx-ext='json-enc' hx-swap="innerHTML" hx-target="#visitor-table">
+    <form id="visitor-filter-form" class="mt-3" onsubmit="return false;" hx-encoding="multipart/form-data" hx-trigger="load, input from:#uid_filter delay:500ms, input from:#still_playing, click from:#clearButton" hx-get="/admin/visitors/table" hx-ext="json-enc" hx-swap="innerHTML" hx-target="#visitor-table">
         <div class="mb-3">
             <label for="uid_filter" class="form-label">Filter by UID:</label>
             <div class="container-fluid px-0">
@@ -79,6 +79,6 @@
         );
         html5QrcodeScanner.render(onScanSuccess);
     }, false);
-    
-</script>  
+
+</script>
 {% endblock %}

--- a/openday_scavenger/views/admin/templates/visitors_pool.html
+++ b/openday_scavenger/views/admin/templates/visitors_pool.html
@@ -8,7 +8,7 @@
 
 <div class="my-4 mx-3 p-3 bg-body shadow-sm admin-panel-container">
     <h5 class="border-bottom pb-2 mb-0">Visitor Pool</h5>
-    <form id='visitor-pool-form' class="mt-3" hx-encoding='multipart/form-data' hx-post='/admin/visitors/pool' hx-ext='json-enc' hx-swap="innerHTML" hx-target="#visitor-pool-table"> 
+    <form id="visitor-pool-form" class="mt-3" hx-encoding="multipart/form-data" hx-post="/admin/visitors/pool" hx-ext="json-enc" hx-swap="innerHTML" hx-target="#visitor-pool-table">
         <div class="mb-3">
             <label for="number_of_entries" class="form-label">Number of UIDs:</label>
             <input type="number" id="number_of_entries" name="number_of_entries" class="form-control" value="10">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,8 @@ show_missing = true
 fail_under = 60
 
 [tool.djlint]
-# TODO: Enforce viewport?
 # Just the 'critical' rules for now. At some point we can enable
 # the full rule set and maybe even enforce formatting of html/templates
-# like we do with python files 
-ignore="H030,H031,J004,H008,J018,H029,H006,H025,H021,T001,T002,T003"
+# like we do with python files
+ignore="H030,H031,J004,J018,H029,H006,H025,H021,T001,T002,T003"
 profile="jinja"


### PR DESCRIPTION
- I wanted to remove a redundant TODO comment in pyproject.toml and thought why not enable another linting rule while I'm there. Double quote is definitely the most common way of quoting HTML attributes (at least in this project) so we may as well be consistent.
- Also remove some trailing spaces in files because my editor just does that automatically on save